### PR TITLE
Add /chat page with Ahmad-focused assistant and 3-prompt session limit

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -1,0 +1,88 @@
+import { NextResponse } from "next/server";
+
+type ChatMessage = {
+  role: "user" | "assistant";
+  content: string;
+};
+
+const SYSTEM_PROMPT = `You are Ahmad's personal AI assistant.
+
+Your identity and scope:
+- You only answer questions related to Muhammad Ahmad (also called Ahmad or bhatti).
+- If a user asks anything unrelated to Muhammad Ahmad, respond exactly with:
+"I am Ahmad's AI and I only answer the questions related to him".
+
+Facts about Muhammad Ahmad:
+- Full name: Muhammad Ahmad.
+- Common nickname among friends: bhatti.
+- From Hafizabad, known for green Basmati rice fields.
+- Studied in public (government) school and college.
+- Played a lot of cricket, represented district and region, and captained the team.
+- Missed necessary exams during an inter-district tournament, then took supplementary exams and scored 60%.
+- Got admission in UCP for bachelor's.
+- Graduated with a silver medal.
+- Loves mathematics as problem solving and curiosity.
+- Solved nearly 200 LeetCode problems.
+- In first job, got earlier-than-expected promotions and exceeded expectations in review cycles.
+- Engineering strengths: street smartness, humbleness, problem solving and curiosity, and people management.
+- Inspired by Steve Jobs's product thinking: understand user needs deeply and backtrack to code.
+
+Style:
+- Keep answers concise, clear, and friendly.
+- If asked for unknown specifics not in the facts above, say you only know limited profile details and avoid making up information.`;
+
+export async function POST(request: Request) {
+  try {
+    const body = (await request.json()) as { messages?: ChatMessage[] };
+    const messages = body.messages ?? [];
+
+    if (!Array.isArray(messages)) {
+      return NextResponse.json({ error: "Invalid messages format." }, { status: 400 });
+    }
+
+    const apiKey = process.env.OPENROUTER_API_KEY;
+    if (!apiKey) {
+      return NextResponse.json(
+        {
+          error:
+            "Missing OPENROUTER_API_KEY. Add it to your environment to enable chat.",
+        },
+        { status: 500 },
+      );
+    }
+
+    const response = await fetch("https://openrouter.ai/api/v1/chat/completions", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        model: "meta-llama/llama-3.3-70b-instruct:free",
+        messages: [{ role: "system", content: SYSTEM_PROMPT }, ...messages],
+        temperature: 0.3,
+      }),
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      return NextResponse.json(
+        { error: `LLM request failed: ${errorText}` },
+        { status: response.status },
+      );
+    }
+
+    const data = (await response.json()) as {
+      choices?: Array<{ message?: { content?: string } }>;
+    };
+
+    const answer = data.choices?.[0]?.message?.content;
+    if (!answer) {
+      return NextResponse.json({ error: "Empty model response." }, { status: 500 });
+    }
+
+    return NextResponse.json({ answer });
+  } catch {
+    return NextResponse.json({ error: "Something went wrong." }, { status: 500 });
+  }
+}

--- a/app/chat/page.tsx
+++ b/app/chat/page.tsx
@@ -1,0 +1,144 @@
+"use client";
+
+import { Button, Card, Flex, Heading, ScrollArea, Text, TextField } from "@radix-ui/themes";
+import { FormEvent, useMemo, useState } from "react";
+
+type ChatMessage = {
+  role: "user" | "assistant";
+  content: string;
+};
+
+const MAX_PROMPTS = 3;
+
+const ChatPage = () => {
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const [input, setInput] = useState("");
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState("");
+
+  const userPromptCount = useMemo(
+    () => messages.filter((message) => message.role === "user").length,
+    [messages],
+  );
+
+  const isLocked = userPromptCount >= MAX_PROMPTS;
+
+  const onSubmit = async (event: FormEvent) => {
+    event.preventDefault();
+
+    const trimmedInput = input.trim();
+    if (!trimmedInput || isLoading || isLocked) {
+      return;
+    }
+
+    const nextMessages: ChatMessage[] = [...messages, { role: "user", content: trimmedInput }];
+
+    setMessages(nextMessages);
+    setInput("");
+    setError("");
+    setIsLoading(true);
+
+    try {
+      const response = await fetch("/api/chat", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ messages: nextMessages }),
+      });
+
+      const data = (await response.json()) as { answer?: string; error?: string };
+      if (!response.ok || !data.answer) {
+        throw new Error(data.error ?? "Failed to get response.");
+      }
+
+      setMessages((previous) => [...previous, { role: "assistant", content: data.answer }]);
+    } catch (submissionError) {
+      setError(
+        submissionError instanceof Error ? submissionError.message : "Unable to send your prompt.",
+      );
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const restartChat = () => {
+    setMessages([]);
+    setInput("");
+    setError("");
+    setIsLoading(false);
+  };
+
+  return (
+    <Flex direction="column" gap="4" mx="auto" style={{ maxWidth: 900, minHeight: "80vh" }}>
+      <Heading size="7">Chat with Ahmad&apos;s AI</Heading>
+      <Text color="gray">You can send up to 3 prompts per session.</Text>
+
+      <Card style={{ flex: 1, minHeight: 450 }}>
+        <ScrollArea type="always" scrollbars="vertical" style={{ height: 420, padding: 16 }}>
+          <Flex direction="column" gap="3">
+            {messages.length === 0 ? (
+              <Text color="gray">Ask anything about Muhammad Ahmad to get started.</Text>
+            ) : (
+              messages.map((message, index) => (
+                <Card
+                  key={`${message.role}-${index}`}
+                  style={{
+                    alignSelf: message.role === "user" ? "flex-end" : "flex-start",
+                    maxWidth: "80%",
+                    backgroundColor:
+                      message.role === "user" ? "var(--lime-4)" : "var(--gray-3)",
+                  }}
+                >
+                  <Text>{message.content}</Text>
+                </Card>
+              ))
+            )}
+            {isLoading ? <Text color="gray">Thinking...</Text> : null}
+          </Flex>
+        </ScrollArea>
+      </Card>
+
+      {error ? <Text color="red">{error}</Text> : null}
+
+      <form onSubmit={onSubmit}>
+        <Flex gap="3">
+          <TextField.Root
+            placeholder={isLocked ? "Session limit reached" : "Type your question and press Enter"}
+            value={input}
+            onChange={(event) => setInput(event.target.value)}
+            disabled={isLocked || isLoading}
+            style={{ flex: 1 }}
+          />
+          <Button type="submit" disabled={isLocked || isLoading || !input.trim()}>
+            Send
+          </Button>
+        </Flex>
+      </form>
+
+      {isLocked ? (
+        <div
+          style={{
+            position: "fixed",
+            inset: 0,
+            background: "rgba(0,0,0,0.7)",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            zIndex: 30,
+          }}
+        >
+          <Card style={{ maxWidth: 460, width: "90%" }}>
+            <Flex direction="column" gap="3">
+              <Heading size="5">Prompt limit reached</Heading>
+              <Text>
+                You have used 3 prompts in this session. Please restart the chat to continue.
+              </Text>
+              <Button onClick={restartChat}>Restart Chat</Button>
+            </Flex>
+          </Card>
+        </div>
+      ) : null}
+    </Flex>
+  );
+};
+
+export default ChatPage;

--- a/constants/navigationItems.ts
+++ b/constants/navigationItems.ts
@@ -10,6 +10,10 @@ const navigationItems: NavigationItemType[] = [
     name: "Path Finder",
     route: "/pathfinder",
   },
+  {
+    name: "Chat",
+    route: "/chat",
+  },
 ];
 
 export default navigationItems;


### PR DESCRIPTION
### Motivation
- Provide a simple ChatGPT-style page that only answers questions about Muhammad Ahmad using a single system prompt (no RAG or persistent history).
- Limit session usage to keep the interface minimal and prevent long interactive sessions by enforcing a 3-prompt per-session cap.

### Description
- Added a new client page at `app/chat/page.tsx` that implements a single-textbox chat UI (Enter-to-send), message list rendering, loading and error states, and no persisted history.
- Implemented session limit logic (`MAX_PROMPTS = 3`) and an overlay modal with a `Restart Chat` button that clears local state when the limit is reached.
- Added a server API route at `app/api/chat/route.ts` which forwards messages to OpenRouter using a fixed `SYSTEM_PROMPT` containing Muhammad Ahmad profile facts and a strict policy to reply only about him; the route expects `OPENROUTER_API_KEY` and uses model `meta-llama/llama-3.3-70b-instruct:free`.
- Exposed the page in navigation by adding a `Chat` item to `constants/navigationItems.ts`, and no additional libraries were introduced (uses existing Next.js + Radix UI components).

### Testing
- Ran `pnpm lint` and it completed successfully with no ESLint warnings or errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a023bfb4c4c832cba068561db5d8200)